### PR TITLE
Add Giphy Core SDK to licenses.html

### DIFF
--- a/WordPress/src/main/assets/licenses.html
+++ b/WordPress/src/main/assets/licenses.html
@@ -44,5 +44,10 @@ libraries are licensed under <a href="http://www.apache.org/licenses/LICENSE-2.0
       <li><a href="https://github.com/wordpress-mobile/GraphView">GraphView</a>: Copyright 2013, Jonas Gehring</li>
     </ul>
 
+    <p>The following is licensed under <a href="https://www.mozilla.org/en-US/MPL/2.0/">Mozilla Public License Version 2.0</a></p>
+    <ul>
+        <li><a href="https://github.com/Giphy/giphy-android-sdk-core">Giphy Core SDK for Android</a></li>
+    </ul>
+
   </body>
 </html>


### PR DESCRIPTION
This is a part of the Giphy picker feature (wordpress-mobile/WordPress-Android#8627). 
